### PR TITLE
add column mapping and financial card example

### DIFF
--- a/src/components/Listing/ListingActions.js
+++ b/src/components/Listing/ListingActions.js
@@ -1,0 +1,32 @@
+import React from "react"
+import queryString from "query-string"
+
+import cs from "./styles.module.css"
+
+function subjectFromType(type) {
+  return `[${type}] - `
+}
+
+function getMailTo(email, subject, message) {
+  return `mailto:${email}?${queryString.stringify({
+    subject,
+    body: message,
+  })}`
+}
+
+export default function ListingActions({ contactMethod, type }) {
+  const contactEmail = process.env.GATSBY_CONTACT_EMAIL
+  const subject = subjectFromType(type)
+  const message =
+    "Dear MAMAS,\n\nI'm contacting you to find out how I can help meet the need for..."
+
+  const mailto = getMailTo(contactEmail, subject, message)
+
+  return (
+    <div className={cs.actions}>
+      <a href={mailto}>
+        <button className={cs.button}>Meet Need</button>
+      </a>
+    </div>
+  )
+}

--- a/src/components/Listing/index.js
+++ b/src/components/Listing/index.js
@@ -43,8 +43,6 @@ const cardNeedTypesMap = {
 export default ({ listing }) => {
   const { type, name, createdAt, contactMethod, meta } = listing
 
-  console.log(meta)
-
   // create separate need cards for various needs within the same row
   let Card = cardNeedTypesMap[type]
   if (!Card) {

--- a/src/components/Listing/index.js
+++ b/src/components/Listing/index.js
@@ -12,8 +12,8 @@ const FinancialNeedCard = ({
   maxFundingNeeded,
   fundingMethod,
 }) => (
-  <div>
-    <table>
+  <table>
+    <tbody>
       <tr>
         <td>Frequency:</td>
         <td>{frequency}</td>
@@ -32,8 +32,8 @@ const FinancialNeedCard = ({
         <td>Preferred Method(s):</td>
         <td>{fundingMethod}</td>
       </tr>
-    </table>
-  </div>
+    </tbody>
+  </table>
 )
 
 const cardNeedTypesMap = {
@@ -42,6 +42,9 @@ const cardNeedTypesMap = {
 
 export default ({ listing }) => {
   const { type, name, createdAt, contactMethod, meta } = listing
+
+  console.log(meta)
+
   // create separate need cards for various needs within the same row
   let Card = cardNeedTypesMap[type]
   if (!Card) {
@@ -59,7 +62,7 @@ export default ({ listing }) => {
         </div>
       </div>
       <div className={cs.listingBody}>
-        <Card meta={meta} />
+        <Card {...meta} />
       </div>
       <ListingActions contactMethod={contactMethod} type={type} />
     </article>

--- a/src/components/Listing/index.js
+++ b/src/components/Listing/index.js
@@ -1,37 +1,59 @@
 import React from "react"
 import moment from "moment"
 
+import { NEEDS_SHEET_COLUMN_INDICES } from "../../utils/listingUtils"
 import cs from "./styles.module.css"
 
+const FinancialNeedCard = listing => (
+  <div>
+    <table>
+      <tr>
+        <td>Frequency:</td>
+        <td>{listing[NEEDS_SHEET_COLUMN_INDICES.financial_needFrequency]}</td>
+      </tr>
+      <tr>
+        <td>Timing:</td>
+        <td>{listing[NEEDS_SHEET_COLUMN_INDICES.financial_needTiming]}</td>
+      </tr>
+      <tr>
+        <td>Funding Needed:</td>
+        <td>
+          ${listing[NEEDS_SHEET_COLUMN_INDICES.financial_minFundingNeed]} - $
+          {listing[NEEDS_SHEET_COLUMN_INDICES.financial_maxFundingNeed]}
+        </td>
+      </tr>
+      <tr>
+        <td>Preferred Method(s):</td>
+        <td>{listing[NEEDS_SHEET_COLUMN_INDICES.financial_fundingMethod]}</td>
+      </tr>
+    </table>
+  </div>
+)
+
 export default ({ listing }) => {
-  return (
+  // create separate need cards for various needs within the same row
+  let needCards = []
+  if (listing[NEEDS_SHEET_COLUMN_INDICES.isFinancialNeed]) {
+    needCards.push(FinancialNeedCard)
+  }
+
+  return needCards.map(renderer => (
     <article className={cs.listing}>
-      <div className={cs.listingBody}>
-        <div className={cs.title}>
-          <div>
-            <b>{listing["name:"]}</b>
-            <div className={cs.date}>
-              Posted on {moment(listing.timestamp).format("LL")}
-            </div>
+      <div className={cs.title}>
+        <div>
+          <b>{listing[NEEDS_SHEET_COLUMN_INDICES.name] || "Anonymous"}</b>
+          <div className={cs.date}>
+            Posted on{" "}
+            {moment(listing[NEEDS_SHEET_COLUMN_INDICES.createdAt]).format("LL")}
           </div>
         </div>
-        <p>
-          <b>Offer:</b> {listing["pleaseCheckOffWhatYouCanOffer:"]}
-        </p>
-        <p>
-          <b>Supplies/food:</b>{" "}
-          {
-            listing[
-              "areThereAnySuppliesOrFoodThatYouCouldContributeToACommunalPool?PleaseBeSpecificInQuantity"
-            ]
-          }
-        </p>
       </div>
+      <div className={cs.listingBody}>{renderer(listing)}</div>
       <div className={cs.actions}>
         <a href={`mailto:${listing.emailAddress}`}>
-          <button className={cs.button}>Contact person</button>
+          <button className={cs.button}>Meet Need</button>
         </a>
       </div>
     </article>
-  )
+  ))
 }

--- a/src/components/Listing/index.js
+++ b/src/components/Listing/index.js
@@ -2,6 +2,7 @@ import React from "react"
 import moment from "moment"
 
 import { NEED_TYPES } from "../../utils/listingUtils"
+import ListingActions from "./ListingActions"
 import cs from "./styles.module.css"
 
 const FinancialNeedCard = ({
@@ -40,7 +41,7 @@ const cardNeedTypesMap = {
 }
 
 export default ({ listing }) => {
-  const { type, name, createdAt, contact, contactMethod, meta } = listing
+  const { type, name, createdAt, contactMethod, meta } = listing
   // create separate need cards for various needs within the same row
   let Card = cardNeedTypesMap[type]
   if (!Card) {
@@ -60,20 +61,7 @@ export default ({ listing }) => {
       <div className={cs.listingBody}>
         <Card meta={meta} />
       </div>
-      <div className={cs.actions}>
-        {/* FIXME: Not all users have provided email as contact method */}
-        {contactMethod === "email" && (
-          <a href={`mailto:${contact}`}>
-            <button className={cs.button}>Meet Need</button>
-          </a>
-        )}
-        {contactMethod === "phone" && (
-          <a href={`tel:${contact}`}>
-            <button className={cs.button}>Call {contact}</button>
-          </a>
-        )}
-        {/* FIXME: what do we show if the user provided some contact method we don't expect? */}
-      </div>
+      <ListingActions contactMethod={contactMethod} type={type} />
     </article>
   )
 }

--- a/src/components/Listing/index.js
+++ b/src/components/Listing/index.js
@@ -36,12 +36,55 @@ const FinancialNeedCard = ({
   </table>
 )
 
+const SuppliesNeedCard = ({
+  frequency,
+  timing,
+  details,
+  neighborhood,
+  store,
+  shoppingList,
+}) => (
+  <table>
+    <tbody>
+      <tr>
+        <td>Frequency:</td>
+        <td>{frequency}</td>
+      </tr>
+      <tr>
+        <td>Timing:</td>
+        <td>{timing}</td>
+      </tr>
+      <tr>
+        <td>Neighborhood:</td>
+        <td>{neighborhood || "N/A"}</td>
+      </tr>
+      <tr>
+        <td>Store:</td>
+        <td>{store || "N/A"}</td>
+      </tr>
+      {details && (
+        <tr>
+          <td>Details:</td>
+          <td>{details}</td>
+        </tr>
+      )}
+      <tr>
+        <td>Shopping List:</td>
+        <td>{shoppingList || "N/A"}</td>
+      </tr>
+    </tbody>
+  </table>
+)
+
 const cardNeedTypesMap = {
   [NEED_TYPES.FINANCIAL]: FinancialNeedCard,
+  [NEED_TYPES.SUPPLIES]: SuppliesNeedCard,
 }
 
 export default ({ listing }) => {
   const { type, name, createdAt, contactMethod, meta } = listing
+
+  console.log(type)
 
   // create separate need cards for various needs within the same row
   let Card = cardNeedTypesMap[type]

--- a/src/components/ListingResults/index.js
+++ b/src/components/ListingResults/index.js
@@ -6,9 +6,9 @@ import cs from "./styles.module.css"
 function ListingResults({ listings }) {
   return (
     <div className={cs.listings}>
-      {listings.map(listing => (
-        <Listing key={listing.key} listing={listing}></Listing>
-      ))}
+      {listings
+        .map(listing => <Listing key={listing.key} listing={listing}></Listing>)
+        .flat()}
     </div>
   )
 }

--- a/src/components/Listings/index.js
+++ b/src/components/Listings/index.js
@@ -4,38 +4,33 @@ import { connectToSpreadsheet } from "react-google-sheet-connector"
 import classnames from "classnames"
 import { useDebounce } from "use-debounce"
 
-import { TYPES, OFFERS_SHEET_NAME } from "../../utils/listingUtils"
+import { NEEDS_SHEET_NAME } from "../../utils/listingUtils"
 import useTextSearch from "../../utils/useTextSearch"
 import ListingResults from "../ListingResults"
 import cs from "./styles.module.css"
 
-const FULL_TEXT_SEARCH_KEYS = [
-  "name:",
-  "pleaseCheckOffWhatYouCanOffer:",
-  "areThereAnySuppliesOrFoodThatYouCouldContributeToACommunalPool?PleaseBeSpecificInQuantity",
-]
+const FULL_TEXT_SEARCH_KEYS = ["name"]
 
 const Listings =
   typeof window !== `undefined` &&
   connectToSpreadsheet(props => {
-    const [typeFilter, setTypeFilter] = useState(TYPES[0])
+    const [typeFilter, setTypeFilter] = useState(null)
     const [searchTerm, setSearchTerm] = useState("")
     const [debouncedSearchTerm] = useDebounce(searchTerm, 250)
 
     let filters = {}
 
-    if (typeFilter !== TYPES[0]) {
-      filters["typeOfSupport?"] = typeFilter
-    }
+    // if (typeFilter !== TYPES[0]) {
+    //   filters["typeOfSupport?"] = typeFilter
+    // }
 
     // FIXME: choose correct deps to update this memoized result
     // currently only updated once on initial render
     const listings = useMemo(() => {
       return (
         props
-          .getSheet(OFFERS_SHEET_NAME)
+          .getSheet(NEEDS_SHEET_NAME)
           .getData()
-          .filter(l => !!l["name:"])
           // assign a stable unique key for each listing
           .map((l, i) => ({ ...l, key: `listing-${i}` }))
       )
@@ -61,7 +56,7 @@ const Listings =
               onChange={e => setSearchTerm(e.target.value)}
               className={classnames(cs.filter)}
             ></input>
-            {TYPES.map(filter => (
+            {/* {TYPES.map(filter => (
               <button
                 key={filter}
                 className={classnames(cs.filter, {
@@ -74,10 +69,10 @@ const Listings =
               >
                 {filter}
               </button>
-            ))}
+            ))} */}
           </div>
-          <ListingResults listings={searchResult} />
         </div>
+        <ListingResults listings={searchResult} />
       </div>
     )
   })

--- a/src/components/Listings/index.js
+++ b/src/components/Listings/index.js
@@ -2,18 +2,15 @@ import React, { useMemo, useReducer } from "react"
 import { Link } from "gatsby"
 import { connectToSpreadsheet } from "react-google-sheet-connector"
 import classnames from "classnames"
-import { useDebounce } from "use-debounce"
 
 import {
   NEEDS_SHEET_NAME,
   NEED_TYPES,
   NEEDS_SHEET_COLUMN_INDICES,
 } from "../../utils/listingUtils"
-import useTextSearch from "../../utils/useTextSearch"
+import useFilteredListings from "../../utils/useFilteredListings"
 import ListingResults from "../ListingResults"
 import cs from "./styles.module.css"
-
-const FULL_TEXT_SEARCH_KEYS = ["name"]
 
 /**
  * A reducer which parses a row from the sheet and adds the needs data to the array of all needs
@@ -53,20 +50,6 @@ function parseRow(result, row, index) {
   return result
 }
 
-/**
- * Returns a filter function which filters listings.
- * @param {*} needs
- * @param {*} filters
- */
-function createListingsFilter(filters) {
-  return listing => {
-    if (filters.typeFilter && filters.typeFilter !== listing.type) {
-      return false
-    }
-    return true
-  }
-}
-
 function filterReducer(state, action) {
   switch (action.type) {
     case "setTypeFilter":
@@ -77,22 +60,6 @@ function filterReducer(state, action) {
     default:
       throw new Error(`invalid action type ${action.type}`)
   }
-}
-
-function useFilteredListings(filters, listings) {
-  const listingsFilter = useMemo(() => createListingsFilter(filters), [filters])
-  const filteredListings = useMemo(() => listings.filter(listingsFilter), [
-    listings,
-    listingsFilter,
-  ])
-  const [debouncedSearchTerm] = useDebounce(filters.searchTerm, 250)
-
-  const searchResult = useTextSearch(
-    filteredListings,
-    FULL_TEXT_SEARCH_KEYS,
-    debouncedSearchTerm
-  )
-  return searchResult
 }
 
 const Listings =

--- a/src/components/Listings/index.js
+++ b/src/components/Listings/index.js
@@ -36,7 +36,7 @@ function parseRow(result, row, index) {
       // any data parsed out of the row that is needed by the financial card
       frequency: row[NEEDS_SHEET_COLUMN_INDICES.financial_needFrequency],
       timing: row[NEEDS_SHEET_COLUMN_INDICES.financial_needTiming],
-      minfundingNeeded:
+      minFundingNeeded:
         row[NEEDS_SHEET_COLUMN_INDICES.financial_minFundingNeed],
       maxFundingNeeded:
         row[NEEDS_SHEET_COLUMN_INDICES.financial_maxFundingNeed],

--- a/src/components/Listings/index.js
+++ b/src/components/Listings/index.js
@@ -20,7 +20,17 @@ import cs from "./styles.module.css"
  * @param {*} index
  */
 function parseRow(result, row, index) {
-  const rowNeeds = []
+  const sharedCardProps = {
+    id: `listing-${index}`,
+    type: NEED_TYPES.FINANCIAL,
+    name: row[NEEDS_SHEET_COLUMN_INDICES.name] || "Anonymous",
+    createdAt: row[NEEDS_SHEET_COLUMN_INDICES.createdAt],
+    contactMethod: row[
+      NEEDS_SHEET_COLUMN_INDICES.preferredContactMethod
+    ]?.toLowerCase(),
+    contact: row[NEEDS_SHEET_COLUMN_INDICES.contact],
+  }
+
   if (row[NEEDS_SHEET_COLUMN_INDICES.isFinancialNeed]) {
     const parsedFinancialMetadata = {
       // any data parsed out of the row that is needed by the financial card
@@ -33,20 +43,12 @@ function parseRow(result, row, index) {
       fundingMethod: row[NEEDS_SHEET_COLUMN_INDICES.financial_fundingMethod],
     }
 
-    rowNeeds.push({
-      id: `listing-${index}-financial`,
-      type: NEED_TYPES.FINANCIAL,
+    result.push({
       meta: parsedFinancialMetadata,
-      name: row[NEEDS_SHEET_COLUMN_INDICES.name] || "Anonymous",
-      createdAt: row[NEEDS_SHEET_COLUMN_INDICES.createdAt],
-      contactMethod: row[
-        NEEDS_SHEET_COLUMN_INDICES.preferredContactMethod
-      ]?.toLowerCase(),
-      contact: row[NEEDS_SHEET_COLUMN_INDICES.contact],
+      ...sharedCardProps,
     })
   }
 
-  result.push(...rowNeeds)
   return result
 }
 

--- a/src/utils/listingUtils.js
+++ b/src/utils/listingUtils.js
@@ -1,4 +1,21 @@
-export const TYPES = ["All", "Food"]
+export const NEEDS_SHEET_NAME = "Form Responses 1"
 
-export const NEEDS_SHEET_NAME = "Needs"
-export const OFFERS_SHEET_NAME = "Community Offerings"
+export const NEEDS_SHEET_COLUMN_INDICES = {
+  createdAt: 0,
+  name: 2,
+  pronouns: 3,
+  location: 4,
+  preferredContactMethod: 5,
+  contact: 6,
+  neighborhoodName: 8,
+  public: 9,
+  isFirstNeed: 11,
+
+  // FINANCIAL NEED
+  isFinancialNeed: 12,
+  financial_needFrequency: 13,
+  financial_needTiming: 14,
+  financial_minFundingNeed: 17,
+  financial_maxFundingNeed: 18,
+  financial_fundingMethod: 19,
+}

--- a/src/utils/listingUtils.js
+++ b/src/utils/listingUtils.js
@@ -18,9 +18,18 @@ export const NEEDS_SHEET_COLUMN_INDICES = {
   financial_minFundingNeed: 17,
   financial_maxFundingNeed: 18,
   financial_fundingMethod: 19,
+
+  // SUPPIES/ERRANDS NEED
+  isSuppliesNeed: 20,
+  supplies_needFrequency: 21,
+  supplies_needTiming: 22,
+  supplies_details: 23,
+  supplies_neighborhood: 24,
+  supplies_store: 25,
+  supplies_shoppingList: 26,
 }
 
 export const NEED_TYPES = {
   FINANCIAL: "Financial",
-  FOOD: "Food",
+  SUPPLIES: "Supplies",
 }

--- a/src/utils/useFilteredListings.js
+++ b/src/utils/useFilteredListings.js
@@ -1,0 +1,51 @@
+import { useMemo } from "react"
+import { useDebounce } from "use-debounce"
+
+import useTextSearch from "./useTextSearch"
+const FULL_TEXT_SEARCH_KEYS = ["name"]
+
+/**
+ * Return true if a listing has the same type as the value of typeFilter
+ * or the typeFilter is not set. False otherwise.
+ * @param {*} filters
+ * @param {*} listing
+ */
+const filterByType = (filters, listing) =>
+  !filters.typeFilter || listing.type === filters.typeFilter
+
+/**
+ * TODO: implement date filter
+ * @param  {...any} filters
+ * @param {*} listing
+ */
+const filterByDate = (filters, listing) => true
+
+/**
+ * Curried function which takes one or more filter functions as arguments
+ * and composes them into one filter function which returns true if all
+ * filter functions return true and false otherwise.
+ * @param  {...any} filterFuncs
+ */
+const composeFilters = (...filterFuncs) => filters => listing =>
+  filterFuncs.reduce(
+    (result, filterFunc) => result && filterFunc(filters, listing),
+    true
+  )
+
+const createListingsFilter = composeFilters(filterByType, filterByDate)
+
+export default function useFilteredListings(filters, listings) {
+  const listingsFilter = useMemo(() => createListingsFilter(filters), [filters])
+  const filteredListings = useMemo(() => listings.filter(listingsFilter), [
+    listings,
+    listingsFilter,
+  ])
+  const [debouncedSearchTerm] = useDebounce(filters.searchTerm, 250)
+
+  const searchResult = useTextSearch(
+    filteredListings,
+    FULL_TEXT_SEARCH_KEYS,
+    debouncedSearchTerm
+  )
+  return searchResult
+}


### PR DESCRIPTION
![screenshot-localhost_8000-2020 04 05-10_28_34](https://user-images.githubusercontent.com/339996/78501100-38966900-7728-11ea-9528-ca89d8f8be06.png)

Allows us to break a single need row into multiple cards. For now just started with financial needs. `Listings` is a bit messy while in flux.

Closes #1 